### PR TITLE
Fix libz3 path in Dockerfile and add github action config

### DIFF
--- a/.github/workflows/build-docker-image.yml
+++ b/.github/workflows/build-docker-image.yml
@@ -1,0 +1,46 @@
+name: Create and publish a Docker image
+
+on:
+  push:
+    branches:
+      - "main"
+
+env:
+  REGISTRY: ghcr.io
+  IMAGE_NAME: ${{ github.repository }}
+
+jobs:
+  build-and-push-image:
+    runs-on: ubuntu-latest
+
+    permissions:
+      contents: read
+      packages: write
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Login to Docker Hub
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+        
+      - name: Extract metadata (tags, labels) for Docker
+        id: meta
+        uses: docker/metadata-action@9ec57ed1fcdbf14dcef7dfbe97b2010124a938b7
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+
+      - name: Build and push
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -43,5 +43,8 @@ COPY --from=builder /home/opam/.opam/5.1/lib/stublibs/libz3.so /usr/lib/aarch64-
 COPY --from=builder /home/opam/fptprove/_build/default/main.exe /root/fptprove/
 COPY README.md LICENSE CoAR.opam /root/fptprove/
 COPY config /root/fptprove/config
+# Copy ocaml library for ocaml program verification
+COPY --from=builder /home/opam/.opam/5.1/lib/ocaml /home/opam/.opam/5.1/lib/ocaml
 
+ENV PATH="${PATH}:/root/fptprove"
 CMD ["/bin/bash"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -37,7 +37,8 @@ RUN apt update \
  && apt clean \
  && rm -rf /var/lib/apt/lists/*
 # Copy a stub library to call libz3 from a ocaml program
-COPY --from=builder /home/opam/.opam/5.0/lib/stublibs/libz3.so /usr/lib/x86_64-linux-gnu/
+COPY --from=builder /home/opam/.opam/5.1/lib/stublibs/libz3.so /usr/lib/x86_64-linux-gnu/
+COPY --from=builder /home/opam/.opam/5.1/lib/stublibs/libz3.so /usr/lib/aarch64-linux-gnu/
 # Copy fptprove
 COPY --from=builder /home/opam/fptprove/_build/default/main.exe /root/fptprove/
 COPY README.md LICENSE CoAR.opam /root/fptprove/


### PR DESCRIPTION
This PR includes the following 3 fixes and adds a GitHub action configuration.

1. Docker image failed to build because of incorrect libz3 path

On [line 40 of Dockerfile](https://github.com/hiroshi-unno/coar/blob/f677d82b56c7c8dcee3cd2d193ddb23028537b56/Dockerfile#L40), the opam library directory should be updated to `5.1` to reflect the change in commit f9176e4.

2. `libz3` path is hard-coded for `x86_64` in the result image

Similarly, the current dockerfile only copies `libz3` to `/usr/lib/x86_64-linux-gnu/`, resulting in missing the libz3 dependency in arm64 images. To address this issue, I added a copy statement to `/usr/lib/aarch64-linux-gnu/`.

(Note that while we could do better than this hardcoding approach, e.g., using some conditionals, I could not find any obvious approach to do that. Any feedback would be appreciated)

3. `(Failure "Env.Error:Unbound module Stdlib")` when running the ocaml program verification example in README

The resulting OCaml binary `main.exe` needs ocaml standard library to run the spacer example.

```shell
main.exe -c ./config/solver/dbg_rcaml_spacer.json -p ml ./benchmarks/OCaml/safety/simple/sum.ml
Uncaught exception:
  
  (Failure "Env.Error:Unbound module Stdlib")

Raised at Stdlib.failwith in file "stdlib.ml", line 29, characters 17-33
...
```

Thank you for your work maintaining this wonderful project. 